### PR TITLE
fix: correctly set line caps

### DIFF
--- a/geodesic.go
+++ b/geodesic.go
@@ -37,11 +37,8 @@ const (
 	nA2                        = geographicLibGeodesicOrder
 	nC2                        = geographicLibGeodesicOrder
 	nA3                        = geographicLibGeodesicOrder
-	nA3x                       = nA3
 	nC3                        = geographicLibGeodesicOrder
-	nC3x                       = ((nC3 * (nC3 - 1)) / 2)
 	nC4                        = geographicLibGeodesicOrder
-	nC4x                       = ((nC4 * (nC4 + 1)) / 2)
 	nC                         = (geographicLibGeodesicOrder + 1)
 	tol0                       = epsilon
 	realmin                    = math.SmallestNonzeroFloat64
@@ -77,14 +74,12 @@ const (
 )
 
 const (
-	capNone = 0
-	capC1   = 1 << 0
-	capC1p  = 1 << 1
-	capC2   = 1 << 2
-	capC3   = 1 << 3
-	capC4   = 1 << 4
-	capAll  = 0x1F
-	outAll  = 0x7F80
+	capC1  = 1 << 0
+	capC1p = 1 << 1
+	capC2  = 1 << 2
+	capC3  = 1 << 3
+	capC4  = 1 << 4
+	outAll = 0x7F80
 )
 
 var (
@@ -1697,8 +1692,10 @@ func geodLineInitInt(
 	l.c2 = g.c2
 	l.f1 = g.f1
 	/* If caps is 0 assume the standard direct calculation */
-	if caps != 0 {
+	if caps == 0 {
 		l.caps = DistanceIn | Longitude
+	} else {
+		l.caps = caps
 	}
 	/* always allow latitude and azimuth and unrolling of longitude */
 	l.caps |= Latitude | Azimuth | Mask(LongUnroll)

--- a/geodesic_test.go
+++ b/geodesic_test.go
@@ -133,3 +133,41 @@ func TestSpherical(t *testing.T) {
 		}
 	}
 }
+
+func TestLineInitFlags(t *testing.T) {
+	lat0, lon0, azi0 := 37.750000, -17.500000, 5.793761558385
+	line := WGS84.LineInit(lat0, lon0, azi0,
+		Distance|DistanceIn|ReducedLength|GeodesicScale|Area,
+	)
+
+	s := 1899641.643510
+	var lat2, lon2, azi2, s12, m12, M12, M21, S12 float64
+	line.GenPosition(NoFlags,
+		s, &lat2, &lon2, &azi2, &s12, &m12, &M12, &M21, &S12,
+	)
+
+	if lat2 == 0 {
+		t.Error("gen pos: missing lat2")
+	}
+	if lon0 == 0 {
+		t.Error("gen pos: missing lon0")
+	}
+	if azi2 == 0 {
+		t.Error("gen pos: missing azi2")
+	}
+	if s12 == 0 {
+		t.Error("gen pos: missing s12")
+	}
+	if m12 == 0 {
+		t.Error("gen pos: missing m12")
+	}
+	if M12 == 0 {
+		t.Error("gen pos: missing M12")
+	}
+	if M21 == 0 {
+		t.Error("gen pos: missing M21")
+	}
+	if S12 == 0 {
+		t.Error("gen pos: missing S12")
+	}
+}


### PR DESCRIPTION
Correctly set the capability flags in geodLineInitInt which was previously ignoring the passed in caps Mask.

Also:
* Remove dead code flagged by golangci-lint.